### PR TITLE
Fix bug in AudioGraph.getNode

### DIFF
--- a/src/AudioGraph.elm
+++ b/src/AudioGraph.elm
@@ -56,11 +56,11 @@ setNode id node graph =
 
 
 {-| -}
-getNode : NodeID -> AudioGraph -> AudioGraph
+getNode : NodeID -> AudioGraph -> Maybe AudioNode
 getNode id graph =
     case graph of
         AudioGraph g ->
-            AudioGraph { g | nodes = Dict.remove id g.nodes }
+            Dict.get id g.nodes
 
 
 {-| -}


### PR DESCRIPTION
AudioGraph.getNode was erroneously mimicking AudioGraph.removeNode behaviour. It now correctly performs a Dict.get operation and returns a `Maybe AudioNode`.